### PR TITLE
Add options to list setable by XMLRPC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# editor debris
+*~
+.#*
+._*
+.*.sw?
+# OS debris
+.DS_Store
+# ignore temp/state files
+.netrwhist
+

--- a/comments.php
+++ b/comments.php
@@ -1,0 +1,4 @@
+<?php wp_list_comments();
+paginate_comments_links();
+comment_form();
+

--- a/functions.php
+++ b/functions.php
@@ -56,7 +56,7 @@ function oeru_theme_setup() {
 add_action( 'after_setup_theme', 'oeru_theme_setup' );
 
 function oeru_theme_add_category(){
-	$cat_defaults = array(
+	$catarr = array(
 		'cat_name' => "Front Page Featured",
 		'category_description' => "Items to feature on the front page",
 		'category_nicename' => "front-page",

--- a/functions.php
+++ b/functions.php
@@ -98,6 +98,27 @@ function oeru_admin_theme_scripts_and_styles() {
 
 add_action( 'admin_enqueue_scripts', 'oeru_admin_theme_scripts_and_styles' );
 
+// add XMLRPC options
+add_filter( 'xmlrpc_blog_options', function( $xmlrpc_options ) {
+	if (is_array($xmlrpc_options)) {
+		$xmlrpc_options['show_on_front'] = array(
+			'desc'	    => __( 'Show on front' ),
+			'readonly'  => false,
+			'option'    => 'show_on_front'
+		);
+		$xmlrpc_options['page_on_front'] = array(
+			'desc'	    => __( 'Page to show on front page' ),
+			'readonly'  => false,
+			'option'    => 'page_on_front'
+		);
+		$xmlrpc_options['oeru_theme_menu_create'] = array(
+			'desc'	    => __( 'Create the OERu top menu' ),
+			'readonly'  => false,
+			'option'    => 'oeru_theme_menu_create'
+		);
+	}
+	return $xmlrpc_options;
+});
 
 // Custom template tags for this theme.
 require get_template_directory() . '/inc/template-tags.php';


### PR DESCRIPTION
Add a filter function to add options to the list of those writable by XMLRPC, including the new oeru_theme_menu_create option.

Also silence a WordPress error on what may be a variable naming typo and a deprecation warning.
